### PR TITLE
[Refactor/embedding qpm] 기존 POST 요청 로직 GET 요청 추가 분리 + 캐싱 적용

### DIFF
--- a/src/main/java/org/jun/saemangeum/consume/controller/SurveyController.java
+++ b/src/main/java/org/jun/saemangeum/consume/controller/SurveyController.java
@@ -19,13 +19,22 @@ public class SurveyController {
     private final SurveyRecommendationService surveyRecommendationService;
 
     /**
-     * 사용자 설문 결과 추천 응답 데이터 리스트 반환
+     * 사용자 설문 결과 추천 응답 데이터 리스트 생성
      */
     @PostMapping("/recommendation")
-    public List<RecommendationResponse> createSurvey(@RequestBody SurveyCreateRequest request) {
+    public void createSurvey(@RequestBody SurveyCreateRequest request) {
         log.info("{} - 데이터 소비 요청응답", Thread.currentThread().getName());
-        return surveyRecommendationService.createRecommendationsBySurvey(request);
+        surveyRecommendationService.createRecommendationsBySurvey(request);
     }
+
+    /**
+     * 사용자 설문 결과 추천 응답 데이터 리스트 반환
+     */
+    @GetMapping
+    public List<RecommendationResponse> getSurveyResults(@RequestParam("clientId") String clientId) {
+        return surveyRecommendationService.getSurveyRecommendationResults(clientId);
+    }
+
 
     /**
      * 사용자 설문 결과 만족도 반영 요청

--- a/src/main/java/org/jun/saemangeum/consume/controller/SurveyController.java
+++ b/src/main/java/org/jun/saemangeum/consume/controller/SurveyController.java
@@ -23,7 +23,7 @@ public class SurveyController {
      */
     @PostMapping("/recommendation")
     public void createSurvey(@RequestBody SurveyCreateRequest request) {
-        log.info("{} - 데이터 소비 요청응답", Thread.currentThread().getName());
+        log.info("{} - 데이터 소비 POST 요청", Thread.currentThread().getName());
         surveyRecommendationService.createRecommendationsBySurvey(request);
     }
 
@@ -32,6 +32,7 @@ public class SurveyController {
      */
     @GetMapping
     public List<RecommendationResponse> getSurveyResults(@RequestParam("clientId") String clientId) {
+        log.info("{} - 데이터 조회 GET 요청응답", Thread.currentThread().getName());
         return surveyRecommendationService.getSurveyRecommendationResults(clientId);
     }
 
@@ -41,7 +42,7 @@ public class SurveyController {
      */
     @PatchMapping("/update")
     public void updateSurvey(@RequestBody SurveyUpdateRequest request) {
-        log.info("{} - 데이터 소비 업데이트", Thread.currentThread().getName());
+        log.info("{} - 데이터 업데이트 PATCH 요청", Thread.currentThread().getName());
         surveyRecommendationService.updateSurvey(request);
     }
 }

--- a/src/main/java/org/jun/saemangeum/consume/domain/entity/RecommendationLog.java
+++ b/src/main/java/org/jun/saemangeum/consume/domain/entity/RecommendationLog.java
@@ -21,11 +21,11 @@ public class RecommendationLog {
     @Column(name = "content_title")
     private String contentTitle;
 
-    @Column(name = "survey_id")
-    private Long surveyId;
+    @Column(name = "survey_client_id")
+    private String surveyClientId;
 
     public RecommendationLog(IContent content, Survey survey) {
         this.contentTitle = content.getTitle();
-        this.surveyId = survey.getId();
+        this.surveyClientId = survey.getClientId();
     }
 }

--- a/src/main/java/org/jun/saemangeum/consume/domain/entity/Survey.java
+++ b/src/main/java/org/jun/saemangeum/consume/domain/entity/Survey.java
@@ -19,7 +19,7 @@ public class Survey {
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 
-    @Column(name = "client_id")
+    @Column(name = "client_id", unique = true)
     private String clientId; // UUID 클라이언트 id
 
     // 설문 응답

--- a/src/main/java/org/jun/saemangeum/consume/repository/swap/ContentViewRepository.java
+++ b/src/main/java/org/jun/saemangeum/consume/repository/swap/ContentViewRepository.java
@@ -1,9 +1,19 @@
 package org.jun.saemangeum.consume.repository.swap;
 
+import java.util.List;
 import org.jun.saemangeum.consume.domain.swap.ContentView;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
 
 @Repository
 public interface ContentViewRepository extends JpaRepository<ContentView, Long> {
+    @Query(value = """
+        SELECT cv.*
+        FROM recommendation_logs rl
+        JOIN contents_view cv ON rl.content_title = cv.title
+        WHERE rl.survey_client_id = :clientId
+        """, nativeQuery = true)
+    List<ContentView> findRecommendedContentViewsByClientId(@Param("clientId") String clientId);
 }

--- a/src/main/java/org/jun/saemangeum/consume/service/application/SurveyRecommendationService.java
+++ b/src/main/java/org/jun/saemangeum/consume/service/application/SurveyRecommendationService.java
@@ -56,6 +56,7 @@ public class SurveyRecommendationService {
     /**
      * 임시 GET 요청 처리 서비스 로직
      */
+    // 너도 캐싱 대상이 되겠는데?
     public List<RecommendationResponse> getSurveyRecommendationResults(String clientId) {
         List<? extends IContent> contents = StrategyContextHolder.executeGetStrategy(clientId);
 

--- a/src/main/java/org/jun/saemangeum/consume/service/application/SurveyRecommendationService.java
+++ b/src/main/java/org/jun/saemangeum/consume/service/application/SurveyRecommendationService.java
@@ -29,6 +29,13 @@ public class SurveyRecommendationService {
      * 사용자 설문응답 문자열을 일괄 묶어 임베딩 벡터 처리 후, 로그 확보 + 추천 리스트 반환
      */
     public List<RecommendationResponse> createRecommendationsBySurvey(SurveyCreateRequest request) {
+        // 클라이언트 이슈 : 페이지 리랜더링 시 요청이 똑같이 들어오고 있음
+        // 서버에서 어떻게 중복 요청을 막을 수 있을지?
+        // 코드 로직 내에서 요청 자체를 소모시켜버리는 방안으로 생각해보기
+        // 별개의 GET 요청을 만들자?
+        if (surveyService.isExistedClientId(request.clientId()))
+            throw new IllegalArgumentException("해당 클라이언트 ID는 이미 존재합니다. 관리자에게 문의하거나 다시 시도해주세요.");
+
         String age = request.age() > 30 ? "늙은" : "젊은";
         String awareness = ""; // request.resident()
         String text = request.gender() + " " + age + " " + awareness
@@ -41,8 +48,6 @@ public class SurveyRecommendationService {
         List<RecommendationLog> recommendationLogs = contents.stream()
                 .map(e -> new RecommendationLog(e, survey)).toList();
         recommendationLogService.saveALl(recommendationLogs);
-
-        Coordinate coordinate = new Coordinate(0.1, 0.1);
 
         return contents.stream()
                 .map(IContent::to)

--- a/src/main/java/org/jun/saemangeum/consume/service/application/SurveyRecommendationService.java
+++ b/src/main/java/org/jun/saemangeum/consume/service/application/SurveyRecommendationService.java
@@ -10,9 +10,11 @@ import org.jun.saemangeum.consume.service.domain.RecommendationLogService;
 import org.jun.saemangeum.consume.service.domain.SurveyService;
 import org.jun.saemangeum.consume.service.strategy.StrategyContextHolder;
 import org.jun.saemangeum.consume.util.CoordinateCalculator;
+import org.jun.saemangeum.global.cache.CacheNames;
 import org.jun.saemangeum.global.domain.IContent;
 import org.jun.saemangeum.global.exception.ClientIdException;
 import org.jun.saemangeum.global.exception.SatisfactionsException;
+import org.springframework.cache.annotation.Cacheable;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -57,6 +59,7 @@ public class SurveyRecommendationService {
      * 임시 GET 요청 처리 서비스 로직
      */
     // 너도 캐싱 대상이 되겠는데?
+    @Cacheable(cacheNames = CacheNames.RESULTS, key = "#clientId")
     public List<RecommendationResponse> getSurveyRecommendationResults(String clientId) {
         List<? extends IContent> contents = StrategyContextHolder.executeGetStrategy(clientId);
 

--- a/src/main/java/org/jun/saemangeum/consume/service/domain/RecommendationLogService.java
+++ b/src/main/java/org/jun/saemangeum/consume/service/domain/RecommendationLogService.java
@@ -19,10 +19,4 @@ public class RecommendationLogService {
     public void saveALl(List<RecommendationLog> recommendationLogs) {
         recommendationLogRepository.saveAll(recommendationLogs);
     }
-
-    // 너도 캐시 적용이 될까?
-    public List<Long> getRecommendationLogIdsJoinSurveys(AverageRequest request) {
-        return recommendationLogRepository.findContentIdsBySurveyConditions(
-                request.age(), request.gender(), request.city(), request.want(), request.mood());
-    }
 }

--- a/src/main/java/org/jun/saemangeum/consume/service/domain/SurveyService.java
+++ b/src/main/java/org/jun/saemangeum/consume/service/domain/SurveyService.java
@@ -18,6 +18,10 @@ public class SurveyService {
         return surveyRepository.save(survey);
     }
 
+    public boolean isExistedClientId(String clientId) {
+        return surveyRepository.findByClientId(clientId).isPresent();
+    }
+
     public Survey findByClientId(String clientId) {
         return surveyRepository.findByClientId(clientId).orElseThrow(
                 // 커스텀 예외로 전환 + 전역 예외 핸들러 처리

--- a/src/main/java/org/jun/saemangeum/consume/service/strategy/EmbeddingVectorStrategy.java
+++ b/src/main/java/org/jun/saemangeum/consume/service/strategy/EmbeddingVectorStrategy.java
@@ -6,4 +6,5 @@ import java.util.List;
 
 public interface EmbeddingVectorStrategy {
     List<? extends IContent> calculateSimilarity(String text);
+    List<? extends IContent> getContentsByClientId(String clientId);
 }

--- a/src/main/java/org/jun/saemangeum/consume/service/strategy/StrategyContextHolder.java
+++ b/src/main/java/org/jun/saemangeum/consume/service/strategy/StrategyContextHolder.java
@@ -18,10 +18,19 @@ public class StrategyContextHolder {
         }
     }
 
-    public static List<? extends IContent> executeStrategy(String text) {
+    public static List<? extends IContent> executePostStrategy(String text) {
         lock.readLock().lock();
         try {
             return currentStrategy.calculateSimilarity(text);
+        } finally {
+            lock.readLock().unlock();
+        }
+    }
+
+    public static List<? extends IContent> executeGetStrategy(String clientId) {
+        lock.readLock().lock();
+        try {
+            return currentStrategy.getContentsByClientId(clientId);
         } finally {
             lock.readLock().unlock();
         }

--- a/src/main/java/org/jun/saemangeum/consume/service/strategy/TableEmbeddingVectorStrategy.java
+++ b/src/main/java/org/jun/saemangeum/consume/service/strategy/TableEmbeddingVectorStrategy.java
@@ -4,6 +4,7 @@ import lombok.RequiredArgsConstructor;
 import org.jun.saemangeum.global.domain.Content;
 import org.jun.saemangeum.global.domain.IContent;
 import org.jun.saemangeum.global.domain.Vector;
+import org.jun.saemangeum.global.service.ContentService;
 import org.jun.saemangeum.global.service.VectorService;
 import org.jun.saemangeum.pipeline.application.util.VectorCalculator;
 import org.jun.saemangeum.pipeline.infrastructure.api.VectorClient;
@@ -22,6 +23,7 @@ public class TableEmbeddingVectorStrategy implements EmbeddingVectorStrategy {
 
     private final VectorClient vectorClient;
     private final VectorService vectorService;
+    private final ContentService contentService;
 
     @Override
     public List<? extends IContent> calculateSimilarity(String text) {
@@ -55,6 +57,12 @@ public class TableEmbeddingVectorStrategy implements EmbeddingVectorStrategy {
         float[] floats = new float[floatBuffer.remaining()];
         floatBuffer.get(floats);
         return floats;
+    }
+
+    // 클라이언트 ID 기반 사용자 설문 응답 조회하기
+    @Override
+    public List<? extends IContent> getContentsByClientId(String clientId) {
+        return contentService.getContentsByClientId(clientId);
     }
 
     // 유사도 내부 클래스

--- a/src/main/java/org/jun/saemangeum/consume/service/strategy/TableEmbeddingVectorStrategy.java
+++ b/src/main/java/org/jun/saemangeum/consume/service/strategy/TableEmbeddingVectorStrategy.java
@@ -28,7 +28,7 @@ public class TableEmbeddingVectorStrategy implements EmbeddingVectorStrategy {
         EmbeddingResponse response = vectorClient.get(text);
         float[] requestVec = VectorCalculator.addNoise(response.result().embedding());
 
-        List<Vector> vectors = vectorService.getVectors(); // 이거 캐싱 대상이겠는데?
+        List<Vector> vectors = vectorService.getVectors(); // 이놈도 캐시 추가
         PriorityQueue<TableEmbeddingVectorStrategy.ContentSimilarity> pq = new PriorityQueue<>();
 
         for (Vector vec : vectors) {

--- a/src/main/java/org/jun/saemangeum/consume/service/strategy/TableEmbeddingVectorStrategy.java
+++ b/src/main/java/org/jun/saemangeum/consume/service/strategy/TableEmbeddingVectorStrategy.java
@@ -27,7 +27,7 @@ public class TableEmbeddingVectorStrategy implements EmbeddingVectorStrategy {
 
     @Override
     public List<? extends IContent> calculateSimilarity(String text) {
-        EmbeddingResponse response = vectorClient.get(text);
+        EmbeddingResponse response = vectorClient.getWithCache(text);
         float[] requestVec = VectorCalculator.addNoise(response.result().embedding());
 
         List<Vector> vectors = vectorService.getVectors(); // 이놈도 캐시 추가

--- a/src/main/java/org/jun/saemangeum/consume/service/strategy/ViewEmbeddingVectorStrategy.java
+++ b/src/main/java/org/jun/saemangeum/consume/service/strategy/ViewEmbeddingVectorStrategy.java
@@ -57,6 +57,12 @@ public class ViewEmbeddingVectorStrategy implements EmbeddingVectorStrategy {
         return floats;
     }
 
+    // 클라이언트 ID 기반 사용자 설문 응답 조회하기
+    @Override
+    public List<? extends IContent> getContentsByClientId(String clientId) {
+        return swapViewService.getContentViewsByClientId(clientId);
+    }
+
     // 유사도 내부 클래스
     record ContentSimilarity(ContentView contentView, double similarity)
             implements Comparable<ViewEmbeddingVectorStrategy.ContentSimilarity> {

--- a/src/main/java/org/jun/saemangeum/consume/service/strategy/ViewEmbeddingVectorStrategy.java
+++ b/src/main/java/org/jun/saemangeum/consume/service/strategy/ViewEmbeddingVectorStrategy.java
@@ -25,7 +25,7 @@ public class ViewEmbeddingVectorStrategy implements EmbeddingVectorStrategy {
 
     @Override
     public List<? extends IContent> calculateSimilarity(String text) {
-        EmbeddingResponse response = vectorClient.get(text);
+        EmbeddingResponse response = vectorClient.getWithCache(text);
         float[] requestVec = VectorCalculator.addNoise(response.result().embedding());
 
         List<VectorView> vectorViews = swapViewService.getVectorViews(); // 이거 캐싱 대상이겠는데?

--- a/src/main/java/org/jun/saemangeum/consume/service/swap/SwapViewService.java
+++ b/src/main/java/org/jun/saemangeum/consume/service/swap/SwapViewService.java
@@ -1,6 +1,7 @@
 package org.jun.saemangeum.consume.service.swap;
 
 import lombok.RequiredArgsConstructor;
+import org.jun.saemangeum.consume.domain.swap.ContentView;
 import org.jun.saemangeum.consume.domain.swap.VectorView;
 import org.jun.saemangeum.consume.repository.swap.ContentViewRepository;
 import org.jun.saemangeum.consume.repository.swap.VectorViewRepository;
@@ -19,5 +20,9 @@ public class SwapViewService {
 
     public List<VectorView> getVectorViews() {
         return vectorViewRepository.findAllWithContentView();
+    }
+
+    public List<ContentView> getContentViewsByClientId(String clientId) {
+        return contentViewRepository.findRecommendedContentViewsByClientId(clientId);
     }
 }

--- a/src/main/java/org/jun/saemangeum/consume/util/CoordinateCalculator.java
+++ b/src/main/java/org/jun/saemangeum/consume/util/CoordinateCalculator.java
@@ -35,6 +35,8 @@ public class CoordinateCalculator {
     private final HttpClient httpClient = HttpClient.newHttpClient();
 
     public Coordinate getCoordinate(String position) {
+        // 여기도 캐시 추가
+
         String responseJson = getResponseJson(position);
         KakaoResponse body = null;
 

--- a/src/main/java/org/jun/saemangeum/global/cache/CacheExpirePolicy.java
+++ b/src/main/java/org/jun/saemangeum/global/cache/CacheExpirePolicy.java
@@ -1,0 +1,30 @@
+package org.jun.saemangeum.global.cache;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.cache.CacheManager;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Component;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class CacheExpirePolicy {
+
+    private final CacheManager cacheManager;
+
+    @Scheduled(cron = "0 0 3 ? * SUN", zone = "Asia/Seoul")
+    public void evictWeeklyCache() {
+        log.info("벡터 데이터리스트 캐시 & 컨텐츠 문자열 전처리 키 기반 캐시 무효화");
+
+        if (cacheManager.getCache(CacheNames.VECTORS) != null) {
+            cacheManager.getCache(CacheNames.VECTORS).clear();
+            log.info("벡터 데이터리스트 캐시 만료 처리");
+        }
+
+        if (cacheManager.getCache(CacheNames.EMBEDDING) != null) {
+            cacheManager.getCache(CacheNames.EMBEDDING).clear();
+            log.info("컨텐츠 문자열 전처리 키 기반 캐시 만료 처리");
+        }
+    }
+}

--- a/src/main/java/org/jun/saemangeum/global/cache/CacheNames.java
+++ b/src/main/java/org/jun/saemangeum/global/cache/CacheNames.java
@@ -1,0 +1,7 @@
+package org.jun.saemangeum.global.cache;
+
+public class CacheNames {
+    public static final String VECTORS = "vectors";
+    public static final String EMBEDDING = "embedding";
+    public static final String RESULTS = "results";
+}

--- a/src/main/java/org/jun/saemangeum/global/cache/CacheType.java
+++ b/src/main/java/org/jun/saemangeum/global/cache/CacheType.java
@@ -7,11 +7,11 @@ import lombok.Getter;
 @AllArgsConstructor
 public enum CacheType {
     // 벡터와 임베딩 캐시는 스케줄러 할당으로 강제 비우기 예정
-    VECTORS("vectors", 7 * 24 * 60, 1000), // 7일 만료, 최대 1000개
-    EMBEDDING("embedding", 7 * 24 * 60, 1000), // 7일 만료, 최대 1000개
-    RESULTS("results", 10, 1000); // 10분 만료, 최대 1000개
+    VECTORS(CacheNames.VECTORS, 7 * 24 * 60, 1000), // 7일 만료, 최대 1000개
+    EMBEDDING(CacheNames.EMBEDDING, 7 * 24 * 60, 1000), // 7일 만료, 최대 1000개
+    RESULTS(CacheNames.RESULTS, 10, 1000); // 10분 만료, 최대 1000개
 
-    private final String cacheName;
-    private final int expiredAfterWrite; // 만료 시간(분 단위)
-    private final int maximumSize; // 캐시 최대 크기 (엔트리 수)
+    private String cacheName;
+    private int expiredAfterWrite; // 만료 시간(분 단위)
+    private int maximumSize; // 캐시 최대 크기 (엔트리 수)
 }

--- a/src/main/java/org/jun/saemangeum/global/cache/CacheType.java
+++ b/src/main/java/org/jun/saemangeum/global/cache/CacheType.java
@@ -1,0 +1,17 @@
+package org.jun.saemangeum.global.cache;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public enum CacheType {
+    // 벡터와 임베딩 캐시는 스케줄러 할당으로 강제 비우기 예정
+    VECTORS("vectors", 7 * 24 * 60, 1000), // 7일 만료, 최대 1000개
+    EMBEDDING("embedding", 7 * 24 * 60, 1000), // 7일 만료, 최대 1000개
+    RESULTS("results", 10, 1000); // 10분 만료, 최대 1000개
+
+    private final String cacheName;
+    private final int expiredAfterWrite; // 만료 시간(분 단위)
+    private final int maximumSize; // 캐시 최대 크기 (엔트리 수)
+}

--- a/src/main/java/org/jun/saemangeum/global/config/CacheConfig.java
+++ b/src/main/java/org/jun/saemangeum/global/config/CacheConfig.java
@@ -1,12 +1,38 @@
 package org.jun.saemangeum.global.config;
 
+import com.github.benmanes.caffeine.cache.Caffeine;
+import java.util.Arrays;
+import java.util.List;
+import java.util.concurrent.TimeUnit;
+import org.jun.saemangeum.global.cache.CacheType;
+import org.springframework.cache.CacheManager;
 import org.springframework.cache.annotation.EnableCaching;
+import org.springframework.cache.caffeine.CaffeineCache;
+import org.springframework.cache.support.SimpleCacheManager;
+import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 
 @Configuration
 @EnableCaching
 public class CacheConfig {
 
-    // org.jun.saemangeum.global.service.VectorService.getVectors()
+    // global.service.VectorService.getVectors()
+    // pipeline.infrastructure.api.VectorClient.getWithCache()
+    // consume.service.application.SurveyRecommendationService.getSurveyRecommendationResults()
 
+    @Bean
+    public CacheManager cacheManager() {
+        SimpleCacheManager cacheManager = new SimpleCacheManager();
+
+        List<CaffeineCache> caches = Arrays.stream(CacheType.values())
+                .map(c -> new CaffeineCache(c.getCacheName(),
+                        Caffeine.newBuilder()
+                                .recordStats().expireAfterWrite(c.getExpiredAfterWrite(), TimeUnit.MINUTES)
+                                .maximumSize(c.getMaximumSize())
+                                .build()))
+                .toList();
+
+        cacheManager.setCaches(caches);
+        return cacheManager;
+    }
 }

--- a/src/main/java/org/jun/saemangeum/global/repository/ContentRepository.java
+++ b/src/main/java/org/jun/saemangeum/global/repository/ContentRepository.java
@@ -3,6 +3,8 @@ package org.jun.saemangeum.global.repository;
 import org.jun.saemangeum.global.domain.Content;
 import org.jun.saemangeum.global.domain.CollectSource;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
 
 import java.util.List;
@@ -12,4 +14,12 @@ public interface ContentRepository extends JpaRepository<Content, Long> {
     List<Content> findByCollectSource(CollectSource collectSource);
     void deleteByCollectSource(CollectSource collectSource);
     int countByCollectSource(CollectSource collectSource);
+
+    @Query(value = """
+        SELECT c.*
+        FROM recommendation_logs rl
+        JOIN contents c ON rl.content_title = c.title
+        WHERE rl.survey_client_id = :clientId
+        """, nativeQuery = true)
+    List<Content> findRecommendedContentsByClientId(@Param("clientId") String clientId);
 } 

--- a/src/main/java/org/jun/saemangeum/global/service/ContentService.java
+++ b/src/main/java/org/jun/saemangeum/global/service/ContentService.java
@@ -1,13 +1,12 @@
 package org.jun.saemangeum.global.service;
 
+import java.util.List;
 import lombok.RequiredArgsConstructor;
+import org.jun.saemangeum.global.domain.CollectSource;
 import org.jun.saemangeum.global.domain.Content;
 import org.jun.saemangeum.global.repository.ContentRepository;
-import org.jun.saemangeum.global.domain.CollectSource;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
-
-import java.util.List;
 
 @Service
 @RequiredArgsConstructor
@@ -23,6 +22,11 @@ public class ContentService {
     @Transactional
     public void deleteByCollectSource(CollectSource collectSource) {
         contentRepository.deleteByCollectSource(collectSource);
+    }
+
+    @Transactional(readOnly = true)
+    public List<Content> getContentsByClientId(String clientId) {
+        return contentRepository.findRecommendedContentsByClientId(clientId);
     }
 
     @Transactional

--- a/src/main/java/org/jun/saemangeum/global/service/VectorService.java
+++ b/src/main/java/org/jun/saemangeum/global/service/VectorService.java
@@ -29,6 +29,7 @@ public class VectorService {
         vectorRepository.deleteAll();
     }
 
+    // 캐싱 대상
     @Transactional(readOnly = true)
     public List<Vector> getVectors() {
         return vectorRepository.findAllWithContent();

--- a/src/main/java/org/jun/saemangeum/global/service/VectorService.java
+++ b/src/main/java/org/jun/saemangeum/global/service/VectorService.java
@@ -1,8 +1,10 @@
 package org.jun.saemangeum.global.service;
 
 import lombok.RequiredArgsConstructor;
+import org.jun.saemangeum.global.cache.CacheNames;
 import org.jun.saemangeum.global.domain.Vector;
 import org.jun.saemangeum.global.repository.VectorRepository;
+import org.springframework.cache.annotation.Cacheable;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -30,6 +32,7 @@ public class VectorService {
     }
 
     // 캐싱 대상
+    @Cacheable(cacheNames = CacheNames.VECTORS)
     @Transactional(readOnly = true)
     public List<Vector> getVectors() {
         return vectorRepository.findAllWithContent();

--- a/src/main/java/org/jun/saemangeum/pipeline/application/service/EmbeddingVectorService.java
+++ b/src/main/java/org/jun/saemangeum/pipeline/application/service/EmbeddingVectorService.java
@@ -5,16 +5,11 @@ import lombok.extern.slf4j.Slf4j;
 import org.jun.saemangeum.global.domain.Content;
 import org.jun.saemangeum.global.domain.Vector;
 import org.jun.saemangeum.global.service.VectorService;
-import org.jun.saemangeum.pipeline.application.util.VectorCalculator;
 import org.jun.saemangeum.pipeline.infrastructure.api.VectorClient;
 import org.jun.saemangeum.pipeline.infrastructure.dto.EmbeddingResponse;
 import org.springframework.stereotype.Service;
 
 import java.nio.ByteBuffer;
-import java.nio.FloatBuffer;
-import java.util.Comparator;
-import java.util.List;
-import java.util.PriorityQueue;
 
 @Slf4j
 @Service
@@ -41,7 +36,7 @@ public class EmbeddingVectorService {
             text = sb.toString().trim();
         };
 
-        EmbeddingResponse response = vectorClient.get(text);
+        EmbeddingResponse response = vectorClient.getWithRaw(text);
         byte[] vectorBytes = floatToByte(response);
         Vector vector = Vector.builder().vector(vectorBytes).content(content).build();
 

--- a/src/main/java/org/jun/saemangeum/pipeline/infrastructure/api/VectorClient.java
+++ b/src/main/java/org/jun/saemangeum/pipeline/infrastructure/api/VectorClient.java
@@ -19,6 +19,8 @@ public class VectorClient {
     }
 
     public EmbeddingResponse get(String text) {
+        // 여기서도 캐시가 있어야 될 것 같은데?
+
         EmbeddingRequest request = new EmbeddingRequest(text);
         return vectorTemplate.postForObject(baseUrl, request, EmbeddingResponse.class);
     }

--- a/src/main/java/org/jun/saemangeum/pipeline/infrastructure/api/VectorClient.java
+++ b/src/main/java/org/jun/saemangeum/pipeline/infrastructure/api/VectorClient.java
@@ -1,8 +1,10 @@
 package org.jun.saemangeum.pipeline.infrastructure.api;
 
+import org.jun.saemangeum.global.cache.CacheNames;
 import org.jun.saemangeum.pipeline.infrastructure.dto.EmbeddingRequest;
 import org.jun.saemangeum.pipeline.infrastructure.dto.EmbeddingResponse;
 import org.springframework.beans.factory.annotation.Value;
+import org.springframework.cache.annotation.Cacheable;
 import org.springframework.stereotype.Component;
 import org.springframework.web.client.RestTemplate;
 
@@ -19,6 +21,7 @@ public class VectorClient {
     }
 
     // 너도 캐싱대상
+    @Cacheable(cacheNames = CacheNames.EMBEDDING, key = "#text")
     public EmbeddingResponse getWithCache(String text) {
         return getWithRaw(text);
     }

--- a/src/main/java/org/jun/saemangeum/pipeline/infrastructure/api/VectorClient.java
+++ b/src/main/java/org/jun/saemangeum/pipeline/infrastructure/api/VectorClient.java
@@ -18,9 +18,12 @@ public class VectorClient {
         this.vectorTemplate = vectorTemplate;
     }
 
-    public EmbeddingResponse get(String text) {
-        // 여기서도 캐시가 있어야 될 것 같은데?
+    // 너도 캐싱대상
+    public EmbeddingResponse getWithCache(String text) {
+        return getWithRaw(text);
+    }
 
+    public EmbeddingResponse getWithRaw(String text) {
         EmbeddingRequest request = new EmbeddingRequest(text);
         return vectorTemplate.postForObject(baseUrl, request, EmbeddingResponse.class);
     }

--- a/src/test/java/org/jun/saemangeum/connect/EmbeddingTest.java
+++ b/src/test/java/org/jun/saemangeum/connect/EmbeddingTest.java
@@ -21,7 +21,7 @@ public class EmbeddingTest {
     @DisplayName("임의의 텍스트 벡터 임베딩 처리")
     void test() {
         String mockData = "오늘 기분이 좋지 않아";
-        EmbeddingResponse embeddingResponse = vectorClient.get(mockData);
+        EmbeddingResponse embeddingResponse = vectorClient.getWithRaw(mockData);
         System.out.println(Arrays.toString(embeddingResponse.result().embedding()));
         assertNotNull(embeddingResponse.result().embedding());
     }


### PR DESCRIPTION
### 기존 POST 요청으로 데이터 전처리 결과 반환을 GET 요청으로 분리
```java
@Slf4j
@RestController
@RequestMapping("/api/survey")
@RequiredArgsConstructor
public class SurveyController {

    private final SurveyRecommendationService surveyRecommendationService;

    // 사용자 설문 결과 추천 응답 데이터 리스트 생성
    @PostMapping("/recommendation")
    public void createSurvey(@RequestBody SurveyCreateRequest request) {
        log.info("{} - 데이터 소비 POST 요청", Thread.currentThread().getName());
        surveyRecommendationService.createRecommendationsBySurvey(request);
    }

    // 사용자 설문 결과 추천 응답 데이터 리스트 반환
    @GetMapping
    public List<RecommendationResponse> getSurveyResults(@RequestParam("clientId") String clientId) {
        log.info("{} - 데이터 조회 GET 요청응답", Thread.currentThread().getName());
        return surveyRecommendationService.getSurveyRecommendationResults(clientId);
    }

    // ...
```

### 조회가 반복되는 3가지 메소드에 대해 스프링 카페인 캐시 적용
1. `global.service.VectorService.getVectors()`
2. `pipeline.infrastructure.api.VectorClient.getWithCache(String text)`
3. `consume.service.application.SurveyRecommendationService.getSurveyRecommendationResults(String clientId)`

---

## 트러블 슈팅
- `getSurveyRecommendationResults(String clientId)` 메소드 호출 과정에서 벡터 엔티티 N+1 문제 발생
- 다만 로직상 벡터를 건드리는 곳은 없어서 의존성 내부의 오류일지 클래스 로딩의 문제일지 면밀히 추가 판단 필요